### PR TITLE
refactor: custodian principal id to stable memory

### DIFF
--- a/src/icp_prototype_backend/src/memory.rs
+++ b/src/icp_prototype_backend/src/memory.rs
@@ -9,7 +9,8 @@ const PRINCIPAL_MEMORY: MemoryId = MemoryId::new(0);
 const LAST_SUBACCOUNT_NONCE_MEMORY: MemoryId = MemoryId::new(1);
 const LAST_BLOCK_MEMORY: MemoryId = MemoryId::new(2);
 const INTERVAL_IN_SECONDS_MEMORY: MemoryId = MemoryId::new(3);
-const TRANSACTIONS_MEMORY: MemoryId = MemoryId::new(5);
+const TRANSACTIONS_MEMORY: MemoryId = MemoryId::new(4);
+const CUSTODIAN_PRINCIPAL_MEMORY: MemoryId = MemoryId::new(5);
 
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
@@ -44,5 +45,11 @@ thread_local! {
         StableBTreeMap::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(TRANSACTIONS_MEMORY))
         )
+    );
+    pub static CUSTODIAN_PRINCIPAL: RefCell<StableCell<StoredPrincipal, Memory>> = RefCell::new(
+        StableCell::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(CUSTODIAN_PRINCIPAL_MEMORY)),
+            StoredPrincipal::default() // TODO: add to init function
+        ).expect("Initializing CUSTODIAN_PRINCIPAL StableCell failed")
     );
 }


### PR DESCRIPTION
**Title**: Refactor `CUSTODIAN_PRINCIPAL_ID` to Initialize via Function Argument

**Description**:
Currently, our codebase hardcodes the `CUSTODIAN_PRINCIPAL_ID` value, which may limit flexibility and scalability. To improve our system's configurability and maintain best coding practices, we need to refactor the way `CUSTODIAN_PRINCIPAL_ID` is set. The task involves modifying the initialization function to accept `CUSTODIAN_PRINCIPAL_ID` as an argument instead of it being hardcoded within the code. This change will make our application more dynamic, allowing for different `CUSTODIAN_PRINCIPAL_ID` values to be used based on the environment or specific requirements.

**Objectives**:
1. Identify all instances where `CUSTODIAN_PRINCIPAL_ID` is currently hardcoded.
2. Modify the initialization (init) function to accept `CUSTODIAN_PRINCIPAL_ID` as an argument.
3. Ensure that all calls to the init function across the project are updated to include the `CUSTODIAN_PRINCIPAL_ID` parameter.
4. Test the changes in different environments to ensure that the application behaves as expected with different `CUSTODIAN_PRINCIPAL_ID` values.
5. Update documentation to reflect the new method of initializing `CUSTODIAN_PRINCIPAL_ID`.

**Acceptance Criteria**:
- The `CUSTODIAN_PRINCIPAL_ID` is no longer hardcoded within the codebase.
- The application initializes `CUSTODIAN_PRINCIPAL_ID` through the init function parameter.
- The system functions correctly with the updated initialization process in all tested scenarios.