### PR TITLE
fix: transactions related bugs

### DIFF
--- a/src/icp_prototype_backend/icp_prototype_backend.did
+++ b/src/icp_prototype_backend/icp_prototype_backend.did
@@ -35,20 +35,21 @@ type Transfer = record {
   amount : E8s;
   spender : opt vec nat8;
 };
-service : (nat64, nat32, text) -> {
+service : (nat64, nat32, text, text) -> {
   add_subaccount : () -> (text);
   canister_status : () -> (Result) query;
-  clear_transactions : (opt nat64, opt Timestamp) -> (Result_1);
+  clear_transactions : (opt nat64, opt nat64, opt Timestamp) -> (Result_1);
   get_interval : () -> (Result_2) query;
-  get_last_block : () -> (nat64) query;
+  get_next_block : () -> (nat64) query;
   get_nonce : () -> (nat32) query;
+  get_oldest_block : () -> (opt nat64) query;
   get_subaccount_count : () -> (nat32) query;
   get_subaccountid : (nat32) -> (Result) query;
   get_transactions_count : () -> (nat32) query;
-  list_transactions : () -> (vec opt StoredTransactions) query;
+  list_transactions : (opt nat64) -> (vec opt StoredTransactions) query;
   refund : (text, text) -> (Result);
   set_interval : (nat64) -> (Result_2);
-  set_last_block : (nat64) -> ();
+  set_next_block : (nat64) -> ();
   sweep_user_vault : (text) -> (Result);
   test_hashing : (nat32) -> (text) query;
 }

--- a/src/icp_prototype_backend/src/lib.rs
+++ b/src/icp_prototype_backend/src/lib.rs
@@ -15,7 +15,7 @@ mod types;
 use account_identifier::{to_hex_string, AccountIdentifier, Subaccount};
 
 use memory::{
-    CUSTODIAN_PRINCIPAL, INTERVAL_IN_SECONDS, LAST_BLOCK, LAST_SUBACCOUNT_NONCE, PRINCIPAL,
+    CUSTODIAN_PRINCIPAL, INTERVAL_IN_SECONDS, NEXT_BLOCK, LAST_SUBACCOUNT_NONCE, PRINCIPAL,
     TRANSACTIONS,
 };
 use types::{
@@ -45,14 +45,10 @@ fn includes_hash(vec_to_check: &Vec<u8>) -> bool {
             let slice = &vec_to_check[..];
             let array_ref: Option<&[u8; 32]> = slice.try_into().ok();
 
-            ic_cdk::println!("got here #1");
-
             match array_ref {
                 Some(array_ref) => {
-                    ic_cdk::println!("got here #2");
                     let hash_key = hash_to_u64(array_ref);
-                    ic_cdk::println!("got here #3");
-                    // LIST_OF_SUBACCOUNTS.with(|subaccounts| subaccounts.borrow().contains_key(&hash_key))
+            
                     LIST_OF_SUBACCOUNTS.with(|subaccounts| {
                         let subaccounts_borrow = subaccounts.borrow();
 
@@ -74,22 +70,22 @@ fn includes_hash(vec_to_check: &Vec<u8>) -> bool {
 }
 
 #[update]
-async fn set_last_block(block: u64) {
-    LAST_BLOCK.with(|last_block_ref| {
-        let _ = last_block_ref.borrow_mut().set(block);
+async fn set_next_block(block: u64) {
+    NEXT_BLOCK.with(|next_block_ref| {
+        let _ = next_block_ref.borrow_mut().set(block);
     });
 }
 
 #[query]
-fn get_last_block() -> u64 {
-    LAST_BLOCK.with(|last_block_ref| *last_block_ref.borrow().get())
+fn get_next_block() -> u64 {
+    NEXT_BLOCK.with(|next_block_ref| *next_block_ref.borrow().get())
 }
 
 async fn call_query_blocks() {
     ic_cdk::println!("Calling query_blocks");
     let ledger_principal = PRINCIPAL.with(|stored_ref| stored_ref.borrow().get().clone());
 
-    let last_block = LAST_BLOCK.with(|last_block_ref| last_block_ref.borrow().get().clone());
+    let next_block = NEXT_BLOCK.with(|next_block_ref| next_block_ref.borrow().get().clone());
 
     let ledger_principal = match ledger_principal.get_principal() {
         Some(result) => result,
@@ -100,7 +96,7 @@ async fn call_query_blocks() {
     };
 
     let req = QueryBlocksQueryRequest {
-        start: last_block,
+        start: next_block,
         length: 100,
     };
     let call_result: CallResult<(Response,)> =
@@ -109,14 +105,14 @@ async fn call_query_blocks() {
     let response = match call_result {
         Ok((response,)) => response,
         Err(_) => {
-            ic_cdk::println!("An error occurred");
+            ic_cdk::println!("query_blocks error occurred");
             return;
         }
     };
 
     ic_cdk::println!("Response: {:?}", response);
 
-    let mut block_count = last_block;
+    let mut block_count = next_block;
     response.blocks.iter().for_each(|block| {
         block.transaction.operation.as_ref().map(|operation| {
             ic_cdk::println!("Operation: {:?}", operation);
@@ -164,14 +160,19 @@ async fn call_query_blocks() {
             };
 
             if subaccount_exist {
+                ic_cdk::println!("Subaccount exists");
                 TRANSACTIONS.with(|transactions_ref| {
                     let mut transactions = transactions_ref.borrow_mut();
+
                     let transaction =
                         StoredTransactions::new(block_count, block.transaction.clone());
+
                     if !transactions.contains_key(&block_count) {
                         // Filter keys that exist
                         ic_cdk::println!("Inserting transaction");
                         let _ = transactions.insert(block_count, transaction);
+                    } else {
+                        ic_cdk::println!("Transaction already exists");
                     }
                 });
             }
@@ -179,7 +180,7 @@ async fn call_query_blocks() {
         block_count += 1;
     });
 
-    let _ = LAST_BLOCK.with(|last_block_ref| last_block_ref.borrow_mut().set(block_count));
+    let _ = NEXT_BLOCK.with(|next_block_ref| next_block_ref.borrow_mut().set(block_count));
 }
 
 #[cfg(not(test))]
@@ -383,22 +384,45 @@ fn get_transactions_count() -> u32 {
 }
 
 #[query]
+fn get_oldest_block() -> Option<u64> {
+    TRANSACTIONS.with(|transactions_ref| {
+        let transactions_borrow = transactions_ref.borrow();
+        transactions_borrow.iter().next().map(|(key, _value)| key)
+    })
+}
+
+#[query]
 fn list_transactions(up_to_count: Option<u64>) -> Vec<Option<StoredTransactions>> {
-    // Get Data
+    // process argument
     let up_to_count = match up_to_count {
         Some(count) => count,
         None => 100, // Default is 100
     };
 
+    // get earliest block
+    // if there are no transactions, return empty `result`
+    let mut result = Vec::new();
+    let oldest_block = get_oldest_block();
+    if let None = oldest_block {
+        return result;
+    }
+
+    let next_block = get_next_block();
+    let recent_block = next_block - 1;
+
     TRANSACTIONS.with(|transactions_ref| {
         let transactions_borrow = transactions_ref.borrow();
-        let mut result = Vec::new();
-        let start = if transactions_borrow.len() > up_to_count {
-            transactions_borrow.len() - up_to_count
+        
+        let start = if transactions_borrow.len() > up_to_count && recent_block - up_to_count >= oldest_block.unwrap() {
+            recent_block - up_to_count
         } else {
-            0
+            oldest_block.unwrap()
         };
-        for i in start..transactions_borrow.len() {
+
+        ic_cdk::println!("start_index: {}", start);
+        ic_cdk::println!("transactions_len: {}", transactions_borrow.len());
+
+        for i in start..next_block {
             result.push(transactions_borrow.get(&i).clone());
         }
         result

--- a/src/icp_prototype_backend/src/memory.rs
+++ b/src/icp_prototype_backend/src/memory.rs
@@ -7,7 +7,7 @@ use crate::types::{Memory, StoredPrincipal, StoredTransactions};
 
 const PRINCIPAL_MEMORY: MemoryId = MemoryId::new(0);
 const LAST_SUBACCOUNT_NONCE_MEMORY: MemoryId = MemoryId::new(1);
-const LAST_BLOCK_MEMORY: MemoryId = MemoryId::new(2);
+const NEXT_BLOCK_MEMORY: MemoryId = MemoryId::new(2);
 const INTERVAL_IN_SECONDS_MEMORY: MemoryId = MemoryId::new(3);
 const TRANSACTIONS_MEMORY: MemoryId = MemoryId::new(4);
 const CUSTODIAN_PRINCIPAL_MEMORY: MemoryId = MemoryId::new(5);
@@ -29,11 +29,11 @@ thread_local! {
             0
         ).expect("Initializing LAST_SUBACCOUNT_NONCE StableCell failed")
     );
-    pub static LAST_BLOCK: RefCell<StableCell<u64, Memory>> = RefCell::new(
+    pub static NEXT_BLOCK: RefCell<StableCell<u64, Memory>> = RefCell::new(
         StableCell::init(
-            MEMORY_MANAGER.with(|m| m.borrow().get(LAST_BLOCK_MEMORY)),
+            MEMORY_MANAGER.with(|m| m.borrow().get(NEXT_BLOCK_MEMORY)),
             0
-        ).expect("Initializing LAST_BLOCK StableCell failed")
+        ).expect("Initializing NEXT_BLOCK StableCell failed")
     );
     pub static INTERVAL_IN_SECONDS: RefCell<StableCell<u64, Memory>> = RefCell::new(
         StableCell::init(


### PR DESCRIPTION
some changes made to list_transactions, and call_query_block:
- `list_transactions` was designed with transactions as vector in mind, so that list was iterated sequentially by index in ascending order ( key -> 0, 1, 2 ... ), when in fact transactions' type is BtreeMap and key was set using `block_number` so that in practice we would have ( key -> 21000000, 21000001 ... ) therefore another function to get the first key from the sequence was introduced using fn `get_oldest_block()`
- `last_block` was in fact assigned value with the most recent block evaluated + 1, so this was changed to `next_block` in order to make it conform with underlying value assignment mechanism 