### PR TITLE
feat: access control

### DIFF
--- a/.maintain/deploy.sh
+++ b/.maintain/deploy.sh
@@ -36,4 +36,4 @@ export CUSTODIAN_PRINCIPAL=$(dfx identity get-principal)
 echo $CUSTODIAN_PRINCIPAL
 
 # Deploy a backend canister
-dfx deploy icp_prototype_backend --argument "(15 : nat64, 10 : nat32  , \"ryjl3-tyaaa-aaaaa-aaaba-cai\", \"$CUSTODIAN_PRINCIPAL\")"
+dfx deploy icp_prototype_backend --argument "(variant { Local }, 15 : nat64, 10 : nat32, \"ryjl3-tyaaa-aaaaa-aaaba-cai\", \"$(echo $CUSTODIAN_PRINCIPAL)\")"

--- a/src/icp_prototype_backend/icp_prototype_backend.did
+++ b/src/icp_prototype_backend/icp_prototype_backend.did
@@ -11,6 +11,7 @@ type Burn = record { from : vec nat8; amount : E8s; spender : opt vec nat8 };
 type E8s = record { e8s : nat64 };
 type Error = record { message : text };
 type Mint = record { to : vec nat8; amount : E8s };
+type Network = variant { Mainnet; Local };
 type Operation = variant {
   Approve : Approve;
   Burn : Burn;
@@ -38,8 +39,8 @@ type Transfer = record {
   amount : E8s;
   spender : opt vec nat8;
 };
-service : (nat64, nat32, text, text) -> {
-  add_subaccount : () -> (text);
+service : (Network, nat64, nat32, text, text) -> {
+  add_subaccount : () -> (Result);
   canister_status : () -> (Result) query;
   clear_transactions : (opt nat64, opt Timestamp) -> (Result_1);
   get_canister_principal : () -> (text) query;
@@ -53,6 +54,6 @@ service : (nat64, nat32, text, text) -> {
   list_transactions : (opt nat64) -> (vec StoredTransactions) query;
   refund : (nat64) -> (Result);
   set_interval : (nat64) -> (Result_2);
-  set_next_block : (nat64) -> ();
+  set_next_block : (nat64) -> (Result_2);
   sweep : () -> (Result_3);
 }

--- a/src/icp_prototype_backend/icp_prototype_backend.did
+++ b/src/icp_prototype_backend/icp_prototype_backend.did
@@ -45,6 +45,7 @@ service : (Network, nat64, nat32, text, text) -> {
   clear_transactions : (opt nat64, opt Timestamp) -> (Result_1);
   get_canister_principal : () -> (text) query;
   get_interval : () -> (Result_2) query;
+  get_network : () -> (Network) query;
   get_next_block : () -> (nat64) query;
   get_nonce : () -> (nat32) query;
   get_oldest_block : () -> (opt nat64) query;

--- a/src/icp_prototype_backend/src/memory.rs
+++ b/src/icp_prototype_backend/src/memory.rs
@@ -3,7 +3,7 @@ use ic_stable_structures::DefaultMemoryImpl;
 use ic_stable_structures::{StableBTreeMap, StableCell};
 use std::cell::RefCell;
 
-use crate::types::{Memory, StoredPrincipal, StoredTransactions};
+use crate::types::{Memory, StoredPrincipal, StoredTransactions, Network};
 
 const PRINCIPAL_MEMORY: MemoryId = MemoryId::new(0);
 const LAST_SUBACCOUNT_NONCE_MEMORY: MemoryId = MemoryId::new(1);
@@ -11,6 +11,7 @@ const NEXT_BLOCK_MEMORY: MemoryId = MemoryId::new(2);
 const INTERVAL_IN_SECONDS_MEMORY: MemoryId = MemoryId::new(3);
 const TRANSACTIONS_MEMORY: MemoryId = MemoryId::new(4);
 const CUSTODIAN_PRINCIPAL_MEMORY: MemoryId = MemoryId::new(5);
+const NETWORK_MEMORY: MemoryId = MemoryId::new(6);
 
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
@@ -51,5 +52,12 @@ thread_local! {
             MEMORY_MANAGER.with(|m| m.borrow().get(CUSTODIAN_PRINCIPAL_MEMORY)),
             StoredPrincipal::default() // TODO: add to init function
         ).expect("Initializing CUSTODIAN_PRINCIPAL StableCell failed")
+    );
+
+    pub static CONNECTED_NETWORK: RefCell<StableCell<Network, Memory>> = RefCell::new(
+        StableCell::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(NETWORK_MEMORY)),
+            Network::Mainnet 
+        ).expect("Initializing NETWORK StableCell failed")
     );
 }

--- a/src/icp_prototype_backend/src/types.rs
+++ b/src/icp_prototype_backend/src/types.rs
@@ -6,6 +6,47 @@ use ic_ledger_types::{BlockIndex, TransferArgs};
 use icrc_ledger_types::icrc1::transfer::TransferArg;
 use serde::Serialize;
 use std::{borrow::Cow, collections::HashMap};
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+pub struct State {
+    pending_requests: BTreeSet<Principal>,
+}
+
+thread_local! {
+    pub static STATE: RefCell<State> = RefCell::new(State{pending_requests: BTreeSet::new()});
+}
+
+#[derive(Deserialize, CandidType, Clone)]
+pub struct CallerGuard {
+    principal: Principal,
+}
+
+impl CallerGuard {
+    pub fn new(principal: Principal) -> Result<Self, String> {
+        STATE.with(|state| {
+            let pending_requests = &mut state.borrow_mut().pending_requests;
+            if pending_requests.contains(&principal){
+                return Err(format!("Already processing a request for principal {:?}", &principal));
+            }
+            pending_requests.insert(principal);
+            Ok(Self { principal })
+        })
+    }
+
+    pub fn unlock(principal: &Principal) {
+        STATE.with(|state| {
+            let flag = state.borrow_mut().pending_requests.remove(principal);
+        })
+    }
+}
+
+impl Drop for CallerGuard {
+    fn drop(&mut self) {
+        STATE.with(|state| {
+            state.borrow_mut().pending_requests.remove(&self.principal);
+        })
+    }
+}
 
 #[derive(CandidType, Deserialize, Serialize, Debug, Copy, Clone, PartialEq)]
 pub enum Network {

--- a/src/icp_prototype_backend/src/types.rs
+++ b/src/icp_prototype_backend/src/types.rs
@@ -22,6 +22,9 @@ thread_local! {
     pub static STATE: RefCell<State> = RefCell::new(State{pending_requests: BTreeSet::new()});
 }
 
+// CallerGuard section was inspired by or directly uses work done by AlphaCQ
+// Their original work can be found at https://github.com/AlphaCQ/IC_Utils
+
 #[derive(Deserialize, CandidType, Clone)]
 pub struct CallerGuard {
     principal: Principal,

--- a/src/icp_prototype_backend/src/types.rs
+++ b/src/icp_prototype_backend/src/types.rs
@@ -7,6 +7,12 @@ use icrc_ledger_types::icrc1::transfer::TransferArg;
 use serde::Serialize;
 use std::{borrow::Cow, collections::HashMap};
 
+#[derive(CandidType, Deserialize, Serialize, Debug, Copy, Clone, PartialEq)]
+pub enum Network {
+    Mainnet,
+    Local,
+}
+
 #[derive(CandidType, Deserialize, Serialize, Clone)]
 pub struct QueryBlocksRequest {
     pub start: u64,


### PR DESCRIPTION
All Canister update methods now are authenticating callers. However for ease of development, if Network is set to Local, the methods would always authenticate to true, whereas for Mainnet, authenticate only accepts requests from pre-configured custodian-principal set during init. This will allow testing via Candid UI during development phase, when setting Network to Local.