### PR TITLE
feat: added methods set_sweep_failed & single_sweep

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,39 @@
+name: Build and Test ICP Prototype Backend
+
+on: [push, pull_request]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.75.0
+        components: rustfmt, clippy
+        override: true
+
+    - name: Install rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        rustup install 1.27.1
+        rustup default 1.27.1
+
+    - name: Install wasm32 target
+      run: rustup target add wasm32-unknown-unknown
+
+    - name: Run cargo fmt
+      run: cargo fmt -- --check
+
+    - name: Run cargo clippy
+      run: cargo clippy -- -D warnings
+
+    - name: Build with cargo
+      run: cargo build --release --target wasm32-unknown-unknown --package icp_prototype_backend
+
+    - name: Run tests with cargo
+      run: cargo test --features "happy_path" && cargo test --features "sad_path"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "generate:did": "npm run generate:did:backend && npm run generate:did:ts",
     "generate:did:ts": "didc bind src/icp_prototype_backend/icp_prototype_backend.did -t ts > src/icp_prototype_backend/icp_prototype_backend.did.ts",
     "generate:did:backend": "cargo build --release --target wasm32-unknown-unknown --package icp_prototype_backend && candid-extractor target/wasm32-unknown-unknown/release/icp_prototype_backend.wasm > src/icp_prototype_backend/icp_prototype_backend.did",
-    "format": "cargo fmt && prettier --write ."
+    "format": "cargo fmt && prettier --write .",
+    "test:happy_path": "cargo test --features 'happy_path'",
+    "test:sad_path": "cargo test --features 'sad_path'",
+    "test": "npm run test:happy_path && npm run test:sad_path"
   },
   "dependencies": {
     "@dfinity/agent": "^1.0.1",

--- a/src/icp_prototype_backend/Cargo.toml
+++ b/src/icp_prototype_backend/Cargo.toml
@@ -33,3 +33,7 @@ num-traits = "0.2.19"
 serde-hex = "0.1.0"
 strum_macros = "0.26.2"
 serde_bytes = "0.11.14"
+
+[features]
+happy_path = []
+sad_path = []

--- a/src/icp_prototype_backend/icp_prototype_backend.did
+++ b/src/icp_prototype_backend/icp_prototype_backend.did
@@ -63,5 +63,7 @@ service : (Network, nat64, nat32, text, text) -> {
   refund : (nat64) -> (Result);
   set_interval : (nat64) -> (Result_8);
   set_next_block : (nat64) -> (Result_8);
+  set_sweep_failed : (text) -> (Result_9);
+  single_sweep : (text) -> (Result_9);
   sweep : () -> (Result_9);
 }

--- a/src/icp_prototype_backend/src/lib.rs
+++ b/src/icp_prototype_backend/src/lib.rs
@@ -998,11 +998,7 @@ async fn set_sweep_failed(tx_hash_arg: String) -> Result<Vec<String>, Error> {
                 ));
             }
             Err(e) => {
-                results.push(format!(
-                    "tx: {}, status_update: {}",
-                    tx.1.index,
-                    e.message
-                ));
+                results.push(format!("tx: {}, status_update: {}", tx.1.index, e.message));
             }
         }
     }

--- a/src/icp_prototype_backend/src/lib.rs
+++ b/src/icp_prototype_backend/src/lib.rs
@@ -902,6 +902,114 @@ async fn sweep() -> Result<Vec<String>, Error> {
     Ok(results)
 }
 
+#[update]
+async fn single_sweep(tx_hash_arg: String) -> Result<Vec<String>, Error> {
+    authenticate().map_err(|e| Error { message: e })?;
+
+    let mut futures = Vec::new();
+
+    // get relevant txs
+    let txs = TRANSACTIONS.with(|transactions_ref| {
+        let transactions_borrow = transactions_ref.borrow();
+
+        // Filter transactions where tx_hash == tx_hash_arg
+        let filtered_transactions: Vec<_> = transactions_borrow
+            .iter()
+            .filter(|(_key, value)| value.tx_hash == tx_hash_arg)
+            .collect();
+
+        filtered_transactions
+    });
+
+    for tx in txs.iter() {
+        let transfer_args = to_sweep_args(&tx.1)?;
+
+        ic_cdk::println!("transfer_args: {:?}", transfer_args);
+
+        let future = InterCanisterCallManager::transfer(transfer_args);
+        futures.push(future);
+    }
+
+    let responses = join_all(futures).await;
+
+    let mut results = Vec::<String>::new();
+
+    // Trigger subsequent process here
+    for (index, response) in responses.iter().enumerate() {
+        let tx = txs[index].1.clone();
+        match response {
+            Ok(_) => {
+                let status_update = update_status(&tx, SweepStatus::Swept);
+                if status_update.is_ok() {
+                    results.push(format!("tx: {}, sweep: ok, status_update: ok", tx.index));
+                } else {
+                    results.push(format!(
+                        "tx: {}, sweep: ok, status_update: {}",
+                        tx.index,
+                        status_update.unwrap_err().message
+                    ));
+                }
+            }
+            Err(e) => {
+                let status_update = update_status(&tx, SweepStatus::FailedToSweep);
+                if status_update.is_ok() {
+                    results.push(format!("tx: {}, sweep: {}, status_update: ok", tx.index, e));
+                } else {
+                    results.push(format!(
+                        "tx: {}, sweep: {}, status_update: {}",
+                        tx.index,
+                        e,
+                        status_update.unwrap_err().message
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+#[update]
+async fn set_sweep_failed(tx_hash_arg: String) -> Result<Vec<String>, Error> {
+    authenticate().map_err(|e| Error { message: e })?;
+
+    let txs = TRANSACTIONS.with(|transactions_ref| {
+        let transactions_borrow = transactions_ref.borrow();
+
+        // Filter transactions where tx_hash == tx_hash_arg
+        let filtered_transactions: Vec<_> = transactions_borrow
+            .iter()
+            .filter(|(_key, value)| value.tx_hash == tx_hash_arg)
+            .collect();
+
+        filtered_transactions
+    });
+
+    let mut results = Vec::<String>::new();
+
+    for tx in txs.iter() {
+        let status_update = update_status(&tx.1, SweepStatus::FailedToSweep);
+        match status_update {
+            Ok(_) => {
+                results.push(format!(
+                    "tx: {}, status_update: ok, new_status: {:?}",
+                    tx.1.index,
+                    SweepStatus::FailedToSweep
+                ));
+            }
+            Err(e) => {
+                results.push(format!(
+                    "tx: {}, status_update: {}",
+                    tx.1.index,
+                    e.message
+                ));
+            }
+        }
+    }
+
+    Ok(results)
+}
+
 fn get_custodian_id() -> Result<AccountIdentifier, String> {
     let custodian_principal_opt =
         CUSTODIAN_PRINCIPAL.with(|stored_ref| stored_ref.borrow().get().clone());

--- a/src/icp_prototype_backend/src/tests.rs
+++ b/src/icp_prototype_backend/src/tests.rs
@@ -22,54 +22,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_get_interval_initial_value() {
-        // Initially, the interval might be unset, or you can set a known value.
-        let expected_seconds: u64 = 0; // Assuming 0 is the default or initial value.
-        let _ = INTERVAL_IN_SECONDS.with(|ref_cell| ref_cell.borrow_mut().set(expected_seconds));
-        assert_eq!(
-            get_interval().unwrap(),
-            expected_seconds,
-            "The interval should initially match the expected default or set value."
-        );
-    }
-
-    #[test]
-    fn test_set_and_get_interval() {
-        let new_seconds: u64 = 10;
-        assert!(
-            set_interval(new_seconds).is_ok(),
-            "Setting the interval should succeed."
-        );
-
-        // Assert the interval was set correctly.
-        assert_eq!(
-            get_interval().unwrap(),
-            new_seconds,
-            "The interval retrieved by get_interval should match the newly set value."
-        );
-    }
-
-    #[test]
-    fn test_set_interval_clears_previous_timer() {
-        // Set an initial interval and timer.
-        let initial_seconds: u64 = 5;
-        set_interval(initial_seconds).unwrap();
-
-        // Set a new interval and timer, which should clear the previous one.
-        let new_seconds: u64 = 10;
-        set_interval(new_seconds).unwrap();
-
-        // Verify the interval was updated.
-        assert_eq!(
-            get_interval().unwrap(),
-            new_seconds,
-            "The interval should be updated to the new value."
-        );
-    }
-
-    #[test]
-    fn create_stored_transactions() {
+    fn setup_principals() -> (AccountIdentifier, AccountIdentifier, AccountIdentifier) {
         // Setup CUSTODIAN_PRINCIPAL with a valid Principal
         let custodian_principal = *STATIC_PRINCIPAL;
         CUSTODIAN_PRINCIPAL.with(|cp| {
@@ -105,91 +58,12 @@ mod tests {
             subaccounts_mut.insert(account_id_hash, from_subaccount);
         });
 
-        let index = 1;
-        let memo = 12345;
-        let icrc1_memo = Some(vec![1, 2, 3, 4]);
-        let operation = Some(Operation::Transfer(Transfer {
-            to: hex_str_to_vec(&to_subaccountid.to_hex()).unwrap(),
-            fee: E8s { e8s: 100 },
-            from: hex_str_to_vec(&from_subaccountid.to_hex()).unwrap(),
-            amount: E8s { e8s: 10000 },
-            spender: Some(hex_str_to_vec(&spender_subaccountid.to_hex()).unwrap()),
-        }));
-        let created_at_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as u64; // Simplified timestamp
-
-        let transaction = Transaction {
-            memo,
-            icrc1_memo: icrc1_memo.clone(),
-            operation: operation.clone(),
-            created_at_time: Timestamp {
-                timestamp_nanos: created_at_time,
-            },
-        };
-
-        let hash = match hash_transaction(&transaction) {
-            Ok(content) => content,
-            Err(_) => "HASH-IS-NOT-AVAILABLE".to_string(),
-        };
-        let stored_transaction = StoredTransactions::new(index, transaction, hash);
-
-        assert_eq!(stored_transaction.index, index);
-        assert_eq!(stored_transaction.memo, memo);
-        assert_eq!(stored_transaction.icrc1_memo, icrc1_memo);
-        assert_eq!(stored_transaction.operation, operation);
-        assert_eq!(
-            stored_transaction.created_at_time,
-            Timestamp {
-                timestamp_nanos: created_at_time
-            }
-        );
-    }
-
-    #[test]
-    fn create_and_retrieve_stored_principal() {
-        let stored_principal = StoredPrincipal::new(*STATIC_PRINCIPAL);
-
-        assert_eq!(stored_principal.get_principal(), Some(*STATIC_PRINCIPAL));
+        (spender_subaccountid, to_subaccountid, from_subaccountid)
     }
 
     // Utility function to populate transactions for testing
     fn populate_transactions(count: u64, timestamp_nanos: Option<u64>) {
-        // Setup CUSTODIAN_PRINCIPAL with a valid Principal
-        let custodian_principal = *STATIC_PRINCIPAL;
-        CUSTODIAN_PRINCIPAL.with(|cp| {
-            let stored_custodian_principal = StoredPrincipal::new(custodian_principal);
-            let _ = cp.borrow_mut().set(stored_custodian_principal);
-        });
-
-        // Setup principal
-        PRINCIPAL.with(|principal_ref| {
-            let stored_principal = StoredPrincipal::new(*STATIC_PRINCIPAL);
-            let _ = principal_ref.borrow_mut().set(stored_principal);
-        });
-
-        let spender_subaccount = nonce_to_subaccount(0);
-        let spender_subaccountid: AccountIdentifier = to_subaccount_id(spender_subaccount);
-
-        let to_subaccount = nonce_to_subaccount(1);
-        let to_subaccountid: AccountIdentifier = to_subaccount_id(to_subaccount);
-
-        let from_subaccount = nonce_to_subaccount(2);
-        let from_subaccountid: AccountIdentifier = to_subaccount_id(from_subaccount);
-
-        LIST_OF_SUBACCOUNTS.with(|subaccounts| {
-            let mut subaccounts_mut = subaccounts.borrow_mut();
-
-            let account_id_hash = spender_subaccountid.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, spender_subaccount);
-
-            let account_id_hash = to_subaccountid.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, to_subaccount);
-
-            let account_id_hash = from_subaccountid.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, from_subaccount);
-        });
+        let (spender_subaccountid, to_subaccountid, from_subaccountid) = setup_principals();
 
         let timestamp_nanos = timestamp_nanos.unwrap_or(1000);
         TRANSACTIONS.with(|transactions_ref| {
@@ -222,160 +96,6 @@ mod tests {
         });
     }
 
-    #[test]
-    fn list_transactions_with_less_than_100_transactions() {
-        populate_transactions(50, None); // Assuming this populates 50 transactions
-
-        let transactions = list_transactions(None);
-        assert_eq!(transactions.unwrap().len(), 50);
-    }
-
-    #[test]
-    fn list_transactions_with_more_than_100_transactions() {
-        populate_transactions(150, None); // Assuming this populates 150 transactions
-
-        let transactions = list_transactions(None);
-        assert_eq!(transactions.unwrap().len(), 100);
-    }
-
-    #[test]
-    fn list_transactions_with_specific_number_transactions() {
-        populate_transactions(150, None); // Assuming this populates 150 transactions
-
-        let transactions = list_transactions(Some(80));
-        assert_eq!(transactions.unwrap().len(), 80);
-
-        let transactions = list_transactions(Some(150));
-        assert_eq!(transactions.unwrap().len(), 150);
-    }
-
-    #[test]
-    fn clear_transactions_with_specific_timestamp() {
-        let nanos = 100000;
-
-        let specific_timestamp = Timestamp::from_nanos(nanos);
-        populate_transactions(100, None);
-
-        let cleared = clear_transactions(None, Some(specific_timestamp)).unwrap();
-        assert_eq!(cleared.len(), 0);
-    }
-
-    #[test]
-    fn clear_transactions_with_similar_timestamp() {
-        let nanos = 100000;
-
-        let specific_timestamp = Timestamp::from_nanos(nanos);
-        populate_transactions(100, Some(nanos));
-
-        let cleared = clear_transactions(None, Some(specific_timestamp)).unwrap();
-        assert_eq!(cleared.len(), 0);
-    }
-
-    #[test]
-    fn clear_transactions_with_none_parameters() {
-        populate_transactions(100, None);
-
-        let cleared = clear_transactions(None, None).unwrap();
-        assert_eq!(cleared.len(), 100); // Assuming no transactions are removed
-    }
-
-    #[test]
-    fn clear_transactions_with_specific_index() {
-        // Assuming each transaction has a unique index
-        populate_transactions(100, None);
-
-        // Clear transactions up to a specific index, excluding transactions with a higher index
-        let cleared = clear_transactions(Some(50), None).unwrap();
-        assert_eq!(
-            cleared.len(),
-            50,
-            "Expected 50 transactions to remain after clearing up to index 50"
-        );
-    }
-
-    #[test]
-    fn clear_transactions_with_multiple_criteria() {
-        populate_transactions(100, Some(50000)); // Populate 100 transactions, all with the same timestamp for simplicity
-
-        // Clear transactions with a count less than 80 and a timestamp less than 60000 nanoseconds
-        let cleared = clear_transactions(Some(80), Some(Timestamp::from_nanos(60000))).unwrap();
-        // This assumes that the criteria are combined with an OR logic, not AND
-        assert_eq!(
-            cleared.len(),
-            0,
-            "Expected 0 transactions to remain after applying multiple clear criteria"
-        );
-    }
-
-    #[test]
-    fn clear_transactions_at_exact_timestamp() {
-        populate_transactions(100, Some(100000)); // Populate transactions with a specific timestamp
-
-        // Clear transactions with a timestamp exactly equal to one of the transactions' timestamps
-        let cleared = clear_transactions(None, Some(Timestamp::from_nanos(100000))).unwrap();
-        // Depending on implementation, this may remove all transactions if they're considered "up to and including" the given timestamp
-        assert!(
-            cleared.is_empty(),
-            "Expected all transactions to be cleared with a timestamp exactly matching the filter"
-        );
-    }
-
-    #[test]
-    fn clear_transactions_edge_cases() {
-        populate_transactions(10, None);
-
-        // Edge case 1: up_to_index is larger than the total transactions
-        let cleared = clear_transactions(Some(50), None).unwrap();
-        assert_eq!(cleared.len(), 0); // Assuming all transactions are cleared
-
-        // Edge case 2: up_to_timestamp is before any stored transaction
-        let early_timestamp = Timestamp::from_nanos(1); // Example early timestamp
-        populate_transactions(10, None); // Repopulate transactions after they were all cleared
-        let cleared = clear_transactions(None, Some(early_timestamp)).unwrap();
-        assert_eq!(cleared.len(), 10); // Assuming no transactions are removed because all are after the timestamp
-    }
-
-    #[test]
-    fn stress_test_for_large_number_of_transactions() {
-        let large_number = 10_000; // Example large number of transactions
-        populate_transactions(large_number, None);
-
-        let transactions = list_transactions(None);
-        assert_eq!(
-            transactions.unwrap().len(),
-            100,
-            "Expected to list only the last 100 transactions from a large dataset"
-        );
-
-        let cleared = clear_transactions(Some(large_number / 2), None).unwrap();
-        // Expecting half of the transactions to be cleared
-        assert_eq!(
-            cleared.len(),
-            (large_number / 2) as usize,
-            "Expected a maximum of 100 transactions to be returned after clearing a large number"
-        );
-    }
-
-    impl InterCanisterCallManagerTrait for InterCanisterCallManager {
-        async fn query_blocks(
-            _ledger_principal: Principal,
-            _req: QueryBlocksRequest,
-        ) -> CallResult<(QueryBlocksResponse,)> {
-            let response = QueryBlocksResponse {
-                certificate: None,       // Assuming no certificate for this example
-                blocks: vec![],          // Assuming no blocks for this example
-                chain_length: 0,         // Example value
-                first_block_index: 0,    // Example value
-                archived_blocks: vec![], // Assuming no archived blocks for this example
-            };
-            Ok((response,))
-        }
-
-        async fn transfer(_args: TransferArgs) -> Result<BlockIndex, String> {
-            Ok(1)
-        }
-    }
-
     impl IcCdkSpawnManagerTrait for IcCdkSpawnManager {
         fn run<F: 'static + Future<Output = ()>>(_future: F) {}
     }
@@ -395,40 +115,7 @@ mod tests {
     }
 
     fn refund_setup() {
-        // Setup CUSTODIAN_PRINCIPAL with a valid Principal
-        let custodian_principal = *STATIC_PRINCIPAL;
-        CUSTODIAN_PRINCIPAL.with(|cp| {
-            let stored_custodian_principal = StoredPrincipal::new(custodian_principal);
-            let _ = cp.borrow_mut().set(stored_custodian_principal);
-        });
-
-        // Setup principal
-        PRINCIPAL.with(|principal_ref| {
-            let stored_principal = StoredPrincipal::new(*STATIC_PRINCIPAL);
-            let _ = principal_ref.borrow_mut().set(stored_principal);
-        });
-
-        let spender_subaccount = nonce_to_subaccount(0);
-        let spender_subaccountid: AccountIdentifier = to_subaccount_id(spender_subaccount);
-
-        let to_subaccount = nonce_to_subaccount(1);
-        let to_subaccountid: AccountIdentifier = to_subaccount_id(to_subaccount);
-
-        let from_subaccount = nonce_to_subaccount(2);
-        let from_subaccountid: AccountIdentifier = to_subaccount_id(from_subaccount);
-
-        LIST_OF_SUBACCOUNTS.with(|subaccounts| {
-            let mut subaccounts_mut = subaccounts.borrow_mut();
-
-            let account_id_hash = spender_subaccountid.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, spender_subaccount);
-
-            let account_id_hash = to_subaccountid.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, to_subaccount);
-
-            let account_id_hash = from_subaccountid.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, from_subaccount);
-        });
+        let (spender_subaccountid, to_subaccountid, from_subaccountid) = setup_principals();
 
         // Setup transactions
         TRANSACTIONS.with(|t| {
@@ -461,69 +148,8 @@ mod tests {
         TRANSACTIONS.with(|t| t.borrow_mut().clear_new());
     }
 
-    #[tokio::test]
-    async fn test_refund_valid_transaction() {
-        refund_setup();
-
-        // Your refund test logic for a valid transaction
-        let result = refund(1);
-        assert!(
-            result.await.is_ok(),
-            "Refund should succeed for a valid transaction"
-        );
-
-        refund_teardown();
-    }
-
-    #[tokio::test]
-    async fn test_refund_nonexistent_transaction() {
-        refund_setup();
-
-        // Attempt to refund a transaction that doesn't exist
-        let result = refund(999); // Assuming transaction with index 999 does not exist
-        assert!(
-            result.await.is_err(),
-            "Refund should fail for a non-existent transaction"
-        );
-
-        refund_teardown();
-    }
-
-    fn setup_sweep_environment() {
-        // Setup CUSTODIAN_PRINCIPAL with a valid Principal
-        let custodian_principal = *STATIC_PRINCIPAL;
-        CUSTODIAN_PRINCIPAL.with(|cp| {
-            let stored_custodian_principal = StoredPrincipal::new(custodian_principal);
-            let _ = cp.borrow_mut().set(stored_custodian_principal);
-        });
-
-        // Setup PRINCIPAL with a valid Principal
-        PRINCIPAL.with(|p| {
-            let stored_principal = StoredPrincipal::new(*STATIC_PRINCIPAL);
-            let _ = p.borrow_mut().set(stored_principal);
-        });
-
-        let spender_subaccount = nonce_to_subaccount(0);
-        let spender_subaccountid: AccountIdentifier = to_subaccount_id(spender_subaccount);
-
-        let to_subaccount = nonce_to_subaccount(1);
-        let to_subaccountid: AccountIdentifier = to_subaccount_id(to_subaccount);
-
-        let from_subaccount = nonce_to_subaccount(2);
-        let from_subaccountid: AccountIdentifier = to_subaccount_id(from_subaccount);
-
-        LIST_OF_SUBACCOUNTS.with(|subaccounts| {
-            let mut subaccounts_mut = subaccounts.borrow_mut();
-
-            let account_id_hash = spender_subaccountid.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, spender_subaccount);
-
-            let account_id_hash = to_subaccountid.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, to_subaccount);
-
-            let account_id_hash = from_subaccountid.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, from_subaccount);
-        });
+    fn setup_sweep_environment() -> Vec<String> {
+        let (spender_subaccountid, to_subaccountid, from_subaccountid) = setup_principals();
 
         // Populate TRANSACTIONS with a mixture of swept and not swept transactions
         TRANSACTIONS.with(|t| t.borrow_mut().clear_new());
@@ -543,11 +169,14 @@ mod tests {
                 })),
                 created_at_time: Timestamp { timestamp_nanos: 0 },
             };
-            let hash = match hash_transaction(&transaction) {
+            let first_hash = match hash_transaction(&transaction) {
                 Ok(content) => content,
                 Err(_) => "HASH-IS-NOT-AVAILABLE".to_string(),
             };
-            transactions.insert(1, StoredTransactions::new(1, transaction, hash));
+            transactions.insert(
+                1,
+                StoredTransactions::new(1, transaction, first_hash.clone()),
+            );
 
             let transaction = Transaction {
                 memo: 101,
@@ -561,12 +190,38 @@ mod tests {
                 })),
                 created_at_time: Timestamp { timestamp_nanos: 0 },
             };
-            let hash = match hash_transaction(&transaction) {
+            let second_hash = match hash_transaction(&transaction) {
                 Ok(content) => content,
                 Err(_) => "HASH-IS-NOT-AVAILABLE".to_string(),
             };
-            transactions.insert(2, StoredTransactions::new(2, transaction, hash));
-        });
+            transactions.insert(
+                2,
+                StoredTransactions::new(2, transaction, second_hash.clone()),
+            );
+
+            let transaction = Transaction {
+                memo: 102,
+                icrc1_memo: None,
+                operation: Some(Operation::Transfer(Transfer {
+                    to: hex_str_to_vec(&to_subaccountid.to_hex()).unwrap(),
+                    fee: E8s { e8s: 100 },
+                    from: hex_str_to_vec(&from_subaccountid.to_hex()).unwrap(),
+                    amount: E8s { e8s: 10000 },
+                    spender: Some(hex_str_to_vec(&spender_subaccountid.to_hex()).unwrap()),
+                })),
+                created_at_time: Timestamp { timestamp_nanos: 0 },
+            };
+            let third_hash = match hash_transaction(&transaction) {
+                Ok(content) => content,
+                Err(_) => "HASH-IS-NOT-AVAILABLE".to_string(),
+            };
+            transactions.insert(
+                3,
+                StoredTransactions::new(3, transaction, third_hash.clone()),
+            );
+
+            vec![first_hash, second_hash, third_hash]
+        })
     }
 
     fn teardown_sweep_environment() {
@@ -575,52 +230,419 @@ mod tests {
         let _ = CUSTODIAN_PRINCIPAL.with(|cp| cp.borrow_mut().set(StoredPrincipal::default()));
     }
 
-    #[tokio::test]
-    async fn test_sweep_successful_sweep() {
-        setup_sweep_environment();
+    mod happy_path_tests {
+        use super::*;
 
-        let result = sweep();
-        assert!(result.await.is_ok(), "Sweeping should be successful.");
+        impl InterCanisterCallManagerTrait for InterCanisterCallManager {
+            async fn query_blocks(
+                _ledger_principal: Principal,
+                _req: QueryBlocksRequest,
+            ) -> CallResult<(QueryBlocksResponse,)> {
+                let response = QueryBlocksResponse {
+                    certificate: None,       // Assuming no certificate for this example
+                    blocks: vec![],          // Assuming no blocks for this example
+                    chain_length: 0,         // Example value
+                    first_block_index: 0,    // Example value
+                    archived_blocks: vec![], // Assuming no archived blocks for this example
+                };
+                Ok((response,))
+            }
 
-        TRANSACTIONS.with(|t| {
-            assert!(
-                t.borrow()
-                    .iter()
-                    .all(|(_, tx)| tx.sweep_status == SweepStatus::Swept),
-                "All transactions should be marked as Swept."
+            async fn transfer(_args: TransferArgs) -> Result<BlockIndex, String> {
+                Ok(1)
+            }
+        }
+
+        #[test]
+        fn test_get_interval_initial_value() {
+            // Initially, the interval might be unset, or you can set a known value.
+            let expected_seconds: u64 = 0; // Assuming 0 is the default or initial value.
+            let _ =
+                INTERVAL_IN_SECONDS.with(|ref_cell| ref_cell.borrow_mut().set(expected_seconds));
+            assert_eq!(
+                get_interval().unwrap(),
+                expected_seconds,
+                "The interval should initially match the expected default or set value."
             );
-        });
+        }
 
-        teardown_sweep_environment();
+        #[test]
+        fn test_set_and_get_interval() {
+            let new_seconds: u64 = 10;
+            assert!(
+                set_interval(new_seconds).is_ok(),
+                "Setting the interval should succeed."
+            );
+
+            // Assert the interval was set correctly.
+            assert_eq!(
+                get_interval().unwrap(),
+                new_seconds,
+                "The interval retrieved by get_interval should match the newly set value."
+            );
+        }
+
+        #[test]
+        fn test_set_interval_clears_previous_timer() {
+            // Set an initial interval and timer.
+            let initial_seconds: u64 = 5;
+            set_interval(initial_seconds).unwrap();
+
+            // Set a new interval and timer, which should clear the previous one.
+            let new_seconds: u64 = 10;
+            set_interval(new_seconds).unwrap();
+
+            // Verify the interval was updated.
+            assert_eq!(
+                get_interval().unwrap(),
+                new_seconds,
+                "The interval should be updated to the new value."
+            );
+        }
+
+        #[test]
+        fn create_stored_transactions() {
+            let (spender_subaccountid, to_subaccountid, from_subaccountid) = setup_principals();
+
+            let index = 1;
+            let memo = 12345;
+            let icrc1_memo = Some(vec![1, 2, 3, 4]);
+            let operation = Some(Operation::Transfer(Transfer {
+                to: hex_str_to_vec(&to_subaccountid.to_hex()).unwrap(),
+                fee: E8s { e8s: 100 },
+                from: hex_str_to_vec(&from_subaccountid.to_hex()).unwrap(),
+                amount: E8s { e8s: 10000 },
+                spender: Some(hex_str_to_vec(&spender_subaccountid.to_hex()).unwrap()),
+            }));
+            let created_at_time = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64; // Simplified timestamp
+
+            let transaction = Transaction {
+                memo,
+                icrc1_memo: icrc1_memo.clone(),
+                operation: operation.clone(),
+                created_at_time: Timestamp {
+                    timestamp_nanos: created_at_time,
+                },
+            };
+
+            let hash = match hash_transaction(&transaction) {
+                Ok(content) => content,
+                Err(_) => "HASH-IS-NOT-AVAILABLE".to_string(),
+            };
+            let stored_transaction = StoredTransactions::new(index, transaction, hash);
+
+            assert_eq!(stored_transaction.index, index);
+            assert_eq!(stored_transaction.memo, memo);
+            assert_eq!(stored_transaction.icrc1_memo, icrc1_memo);
+            assert_eq!(stored_transaction.operation, operation);
+            assert_eq!(
+                stored_transaction.created_at_time,
+                Timestamp {
+                    timestamp_nanos: created_at_time
+                }
+            );
+        }
+
+        #[test]
+        fn create_and_retrieve_stored_principal() {
+            let stored_principal = StoredPrincipal::new(*STATIC_PRINCIPAL);
+
+            assert_eq!(stored_principal.get_principal(), Some(*STATIC_PRINCIPAL));
+        }
+
+        #[test]
+        fn list_transactions_with_less_than_100_transactions() {
+            populate_transactions(50, None); // Assuming this populates 50 transactions
+
+            let transactions = list_transactions(None);
+            assert_eq!(transactions.unwrap().len(), 50);
+        }
+
+        #[test]
+        fn list_transactions_with_more_than_100_transactions() {
+            populate_transactions(150, None); // Assuming this populates 150 transactions
+
+            let transactions = list_transactions(None);
+            assert_eq!(transactions.unwrap().len(), 100);
+        }
+
+        #[test]
+        fn list_transactions_with_specific_number_transactions() {
+            populate_transactions(150, None); // Assuming this populates 150 transactions
+
+            let transactions = list_transactions(Some(80));
+            assert_eq!(transactions.unwrap().len(), 80);
+
+            let transactions = list_transactions(Some(150));
+            assert_eq!(transactions.unwrap().len(), 150);
+        }
+
+        #[test]
+        fn clear_transactions_with_specific_timestamp() {
+            let nanos = 100000;
+
+            let specific_timestamp = Timestamp::from_nanos(nanos);
+            populate_transactions(100, None);
+
+            let cleared = clear_transactions(None, Some(specific_timestamp)).unwrap();
+            assert_eq!(cleared.len(), 0);
+        }
+
+        #[test]
+        fn clear_transactions_with_similar_timestamp() {
+            let nanos = 100000;
+
+            let specific_timestamp = Timestamp::from_nanos(nanos);
+            populate_transactions(100, Some(nanos));
+
+            let cleared = clear_transactions(None, Some(specific_timestamp)).unwrap();
+            assert_eq!(cleared.len(), 0);
+        }
+
+        #[test]
+        fn clear_transactions_with_none_parameters() {
+            populate_transactions(100, None);
+
+            let cleared = clear_transactions(None, None).unwrap();
+            assert_eq!(cleared.len(), 100); // Assuming no transactions are removed
+        }
+
+        #[test]
+        fn clear_transactions_with_specific_index() {
+            // Assuming each transaction has a unique index
+            populate_transactions(100, None);
+
+            // Clear transactions up to a specific index, excluding transactions with a higher index
+            let cleared = clear_transactions(Some(50), None).unwrap();
+            assert_eq!(
+                cleared.len(),
+                50,
+                "Expected 50 transactions to remain after clearing up to index 50"
+            );
+        }
+
+        #[test]
+        fn clear_transactions_with_multiple_criteria() {
+            populate_transactions(100, Some(50000)); // Populate 100 transactions, all with the same timestamp for simplicity
+
+            // Clear transactions with a count less than 80 and a timestamp less than 60000 nanoseconds
+            let cleared = clear_transactions(Some(80), Some(Timestamp::from_nanos(60000))).unwrap();
+            // This assumes that the criteria are combined with an OR logic, not AND
+            assert_eq!(
+                cleared.len(),
+                0,
+                "Expected 0 transactions to remain after applying multiple clear criteria"
+            );
+        }
+
+        #[test]
+        fn clear_transactions_at_exact_timestamp() {
+            populate_transactions(100, Some(100000)); // Populate transactions with a specific timestamp
+
+            // Clear transactions with a timestamp exactly equal to one of the transactions' timestamps
+            let cleared = clear_transactions(None, Some(Timestamp::from_nanos(100000))).unwrap();
+            // Depending on implementation, this may remove all transactions if they're considered "up to and including" the given timestamp
+            assert!(
+                cleared.is_empty(),
+                "Expected all transactions to be cleared with a timestamp exactly matching the filter"
+            );
+        }
+
+        #[test]
+        fn clear_transactions_edge_cases() {
+            populate_transactions(10, None);
+
+            // Edge case 1: up_to_index is larger than the total transactions
+            let cleared = clear_transactions(Some(50), None).unwrap();
+            assert_eq!(cleared.len(), 0); // Assuming all transactions are cleared
+
+            // Edge case 2: up_to_timestamp is before any stored transaction
+            let early_timestamp = Timestamp::from_nanos(1); // Example early timestamp
+            populate_transactions(10, None); // Repopulate transactions after they were all cleared
+            let cleared = clear_transactions(None, Some(early_timestamp)).unwrap();
+            assert_eq!(cleared.len(), 10); // Assuming no transactions are removed because all are after the timestamp
+        }
+
+        #[test]
+        fn stress_test_for_large_number_of_transactions() {
+            let large_number = 10_000; // Example large number of transactions
+            populate_transactions(large_number, None);
+
+            let transactions = list_transactions(None);
+            assert_eq!(
+                transactions.unwrap().len(),
+                100,
+                "Expected to list only the last 100 transactions from a large dataset"
+            );
+
+            let cleared = clear_transactions(Some(large_number / 2), None).unwrap();
+            // Expecting half of the transactions to be cleared
+            assert_eq!(
+                cleared.len(),
+                (large_number / 2) as usize,
+                "Expected a maximum of 100 transactions to be returned after clearing a large number"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_refund_valid_transaction() {
+            refund_setup();
+
+            // Your refund test logic for a valid transaction
+            let result = refund(1);
+            assert!(
+                result.await.is_ok(),
+                "Refund should succeed for a valid transaction"
+            );
+
+            refund_teardown();
+        }
+
+        #[tokio::test]
+        async fn test_sweep_successful_sweep() {
+            setup_sweep_environment();
+
+            let result = sweep();
+            assert!(result.await.is_ok(), "Sweeping should be successful.");
+
+            TRANSACTIONS.with(|t| {
+                assert!(
+                    t.borrow()
+                        .iter()
+                        .all(|(_, tx)| tx.sweep_status == SweepStatus::Swept),
+                    "All transactions should be marked as Swept."
+                );
+            });
+
+            teardown_sweep_environment();
+        }
+
+        #[tokio::test]
+        async fn test_single_sweep_success() {
+            let hashes = setup_sweep_environment();
+
+            let result = single_sweep(hashes[0].to_string()).await.unwrap();
+
+            assert_eq!(result.len(), 1);
+            for res in result {
+                assert!(res.contains("sweep: ok"));
+            }
+
+            teardown_sweep_environment();
+        }
     }
 
-    #[tokio::test]
-    async fn test_sweep_no_custodian_principal_set() {
-        setup_sweep_environment();
-        // Unset the custodian principal
-        let _ = CUSTODIAN_PRINCIPAL.with(|cp| cp.borrow_mut().set(StoredPrincipal::default()));
+    #[cfg(feature = "sad_path")]
+    mod sad_path_tests {
+        use super::*;
 
-        let result = sweep();
-        assert!(
-            result.await.is_err(),
-            "Sweeping should fail without a set custodian principal."
-        );
+        impl InterCanisterCallManagerTrait for InterCanisterCallManager {
+            async fn query_blocks(
+                _ledger_principal: Principal,
+                _req: QueryBlocksRequest,
+            ) -> CallResult<(QueryBlocksResponse,)> {
+                let response = QueryBlocksResponse {
+                    certificate: None,       // Assuming no certificate for this example
+                    blocks: vec![],          // Assuming no blocks for this example
+                    chain_length: 0,         // Example value
+                    first_block_index: 0,    // Example value
+                    archived_blocks: vec![], // Assuming no archived blocks for this example
+                };
+                Ok((response,))
+            }
 
-        teardown_sweep_environment();
-    }
+            async fn transfer(_args: TransferArgs) -> Result<BlockIndex, String> {
+                Err("transfer failed")
+            }
+        }
 
-    #[tokio::test]
-    async fn test_sweep_no_transactions_to_sweep() {
-        setup_sweep_environment();
-        // Clear transactions to simulate no transactions to sweep
-        TRANSACTIONS.with(|t| t.borrow_mut().clear_new());
+        #[tokio::test]
+        async fn test_single_sweep_with_failed_transfer() {
+            let hashes = setup_sweep_environment();
 
-        let result = sweep();
-        assert!(
-            result.await.is_ok(),
-            "Sweeping should succeed even with no transactions to sweep."
-        );
+            let result = single_sweep(hashes[0].to_string()).await.unwrap();
 
-        teardown_sweep_environment();
+            assert_eq!(result.len(), 1);
+            for res in result {
+                if res.contains("sweep: ok") {
+                    assert!(res.contains("status_update: ok"));
+                } else {
+                    assert!(res.contains("sweep:"));
+                    assert!(res.contains("status_update:"));
+                }
+            }
+
+            teardown_sweep_environment();
+        }
+
+        #[tokio::test]
+        async fn test_set_sweep_failed() {
+            let hashes = setup_sweep_environment();
+
+            let result = single_sweep(hashes[0].to_string()).await.unwrap();
+
+            assert_eq!(result.len(), 1);
+            for res in result {
+                assert!(res.contains("status_update: ok"));
+                assert!(res.contains("new_status: FailedToSweep"));
+            }
+
+            teardown_sweep_environment();
+        }
+
+        #[tokio::test]
+        async fn test_refund_nonexistent_transaction() {
+            refund_setup();
+
+            // Attempt to refund a transaction that doesn't exist
+            let result = refund(999); // Assuming transaction with index 999 does not exist
+            assert!(
+                result.await.is_err(),
+                "Refund should fail for a non-existent transaction"
+            );
+
+            refund_teardown();
+        }
+
+        #[tokio::test]
+        async fn test_sweep_no_custodian_principal_set() {
+            setup_sweep_environment();
+            // Unset the custodian principal
+            let _ = CUSTODIAN_PRINCIPAL.with(|cp| cp.borrow_mut().set(StoredPrincipal::default()));
+
+            let result = sweep();
+            assert!(
+                result.await.is_err(),
+                "Sweeping should fail without a set custodian principal."
+            );
+
+            teardown_sweep_environment();
+        }
+
+        #[tokio::test]
+        async fn test_sweep_no_transactions_to_sweep() {
+            setup_sweep_environment();
+            // Clear transactions to simulate no transactions to sweep
+            TRANSACTIONS.with(|t| t.borrow_mut().clear_new());
+
+            let result = sweep();
+            assert!(
+                result.await.is_ok(),
+                "Sweeping should succeed even with no transactions to sweep."
+            );
+
+            teardown_sweep_environment();
+        }
+
+        #[tokio::test]
+        async fn test_set_sweep_failed_nonexistent_hash() {
+            let tx_hash = "nonexistent_hash";
+            let result = set_sweep_failed(tx_hash.to_string()).await.unwrap();
+
+            assert_eq!(result.len(), 0);
+        }
     }
 }

--- a/src/icp_prototype_backend/src/tests.rs
+++ b/src/icp_prototype_backend/src/tests.rs
@@ -230,6 +230,7 @@ mod tests {
         let _ = CUSTODIAN_PRINCIPAL.with(|cp| cp.borrow_mut().set(StoredPrincipal::default()));
     }
 
+    #[cfg(feature = "happy_path")]
     mod happy_path_tests {
         use super::*;
 
@@ -555,7 +556,7 @@ mod tests {
             }
 
             async fn transfer(_args: TransferArgs) -> Result<BlockIndex, String> {
-                Err("transfer failed")
+                Err("transfer failed".to_string())
             }
         }
 


### PR DESCRIPTION
Existing sweep process may experience failure during transfer of one of the transactions. Each failed tx will have its status set to FailedToSweep. 
Method single_sweep is added to specifically re-push transfer tx that has been set to FailedToSweep.
Method set set_sweep_failed is added to manually set a transaction that has not been sweeped to FailedToSweep for testing purposes